### PR TITLE
Adds MySQL Sample App

### DIFF
--- a/mysql/.gitignore
+++ b/mysql/.gitignore
@@ -1,0 +1,1 @@
+cloud-init.yaml

--- a/mysql/Makefile
+++ b/mysql/Makefile
@@ -1,0 +1,41 @@
+.PHONY: run
+run: run-multipass
+
+.PHONY: run-multipass
+run-multipass: cloud-init.yaml
+	@multipass launch -n mysql-sample-app --cloud-init cloud-init.yaml
+
+.PHONY: clean
+clean:
+	@rm -f cloud-init.yaml jinja/variables/cloud-init.yaml
+
+.PHONY: defaultconfig
+defaultconfig:
+	@echo "loki_url: http://loki.k3d.localhost:9999/loki/api/v1/push" >> jinja/variables/cloud-init.yaml; \
+		echo "loki_user: " >> jinja/variables/cloud-init.yaml; \
+		echo "loki_pass: " >> jinja/variables/cloud-init.yaml; \
+		echo "prom_url: http://mimir.k3d.localhost:9999/api/v1/push" >> jinja/variables/cloud-init.yaml; \
+		echo "prom_user: " >> jinja/variables/cloud-init.yaml; \
+		echo "prom_pass:" >> jinja/variables/cloud-init.yaml
+
+
+cloud-init.yaml: jinja/variables/cloud-init.yaml
+	@docker run --rm -it \
+		-v $(shell pwd)/jinja/templates:/templates \
+		-v $(shell pwd)/jinja/variables:/variables \
+		dinutac/jinja2docker:latest /templates/cloud-init-template.yaml /variables/cloud-init.yaml --format=yaml > cloud-init.yaml
+
+jinja/variables/cloud-init.yaml:
+	@echo "Fetching remote write secrets for Grafana Agent Config."
+	@read -p "Enter Loki Server URL: " loki_url; \
+		read -p "Enter Loki Username: " loki_user; \
+		read -p "Enter Loki Password: " loki_pass; \
+		read -p "Enter Prom Server URL: " prom_url; \
+		read -p "Enter Prom Username: " prom_user; \
+		read -p "Enter Prom Password: " prom_pass;\
+		echo "loki_url: $$loki_url" >> jinja/variables/cloud-init.yaml; \
+		echo "loki_user: $$loki_user" >> jinja/variables/cloud-init.yaml; \
+		echo "loki_pass: $$loki_pass" >> jinja/variables/cloud-init.yaml; \
+		echo "prom_url: $$prom_url" >> jinja/variables/cloud-init.yaml; \
+		echo "prom_user: $$prom_user" >> jinja/variables/cloud-init.yaml; \
+		echo "prom_pass: $$prom_pass" >> jinja/variables/cloud-init.yaml

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,0 +1,3 @@
+# TODO
+* Turn the simple shell script into a makefile
+* Automate the population of variables in the cloud init/river of `cloud-init.yaml.template` and write out to `cloud-init.yaml`

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,3 +1,9 @@
-# TODO
-* Turn the simple shell script into a makefile
-* Automate the population of variables in the cloud init/river of `cloud-init.yaml.template` and write out to `cloud-init.yaml`
+# MySQL Sample App
+
+The default makefile action will request some configuration details, then launches a multipass VM running a MySQL server instance, and the Grafana Agent scraping it.
+
+## MySQL Server
+
+There is a MySQL user created for the agent to authenticate with. The credentials for that user are;
+* Username: exporter
+* Password: password

--- a/mysql/jinja/templates/cloud-init-template.yaml
+++ b/mysql/jinja/templates/cloud-init-template.yaml
@@ -1,0 +1,123 @@
+apt:
+  sources:
+    grafana:
+      source: deb https://apt.grafana.com stable main
+      keyid: 963FA27710458545
+      keyserver: https://apt.grafana.com/gpg.key
+
+packages:
+- grafana-agent-flow
+- mysql-server
+
+runcmd:
+- [ sh, -xc, "echo -n 'exporter:password@(localhost:3306)/' > /var/lib/grafana-agent-flow/mysql-secret"]
+- [ chown, root:grafana-agent, /var/lib/grafana-agent-flow/mysql-secret ]
+- [ sed, -e, s/CUSTOM_ARGS=.*/CUSTOM_ARGS="--server.http.listen-addr=0.0.0.0:8080"/g, -i, /etc/default/grafana-agent-flow ]
+- [ systemctl, enable, grafana-agent-flow ]
+- [ systemctl, start, --no-block, grafana-agent-flow ]
+- [ sh, -xc, "echo $(ip r | grep default | cut -d' ' -f3) grafana.k3d.localhost loki.k3d.localhost mimir.k3d.localhost >> /etc/hosts" ]
+- [ sh, -xc, "mysql < /tmp/exporter-user.sql" ]
+
+write_files:
+- owner: root:root
+  path: /tmp/exporter-user.sql
+  content: |
+    CREATE USER 'exporter'@'localhost' IDENTIFIED BY 'password' WITH MAX_USER_CONNECTIONS 3;
+    GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';
+- owner: root:grafana-agent
+  path: /etc/grafana-agent-flow.river
+  content: |
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = "{{loki_url}}"
+
+        {% if loki_user and loki_pass -%}
+        basic_auth {
+          username = "{{loki_user}}"
+          password = "{{loki_pass}}"
+        }
+        {%- endif %}
+      }
+      external_labels = {}
+    }
+
+    local.file_match "logs_integrations_mysql" {
+      path_targets = [{
+        __address__ = "localhost",
+        __path__    = "/var/log/mysql/*.log",
+        instance    = constants.hostname,
+        job         = "integrations/mysql",
+      }]
+    }
+
+    loki.process "logs_integrations_mysql" {
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+
+      stage.regex {
+        expression = "(?P<timestamp>.+) (?P<thread>[\\d]+) \\[(?P<label>.+?)\\]( \\[(?P<err_code>.+?)\\] \\[(?P<subsystem>.+?)\\])? (?P<msg>.+)"
+      }
+
+      stage.labels {
+        values = {
+          err_code  = null,
+          level     = "label",
+          subsystem = null,
+        }
+      }
+
+      stage.drop {
+        drop_counter_reason = "drop empty lines"
+        expression          = "^ *$"
+      }
+    }
+
+    loki.source.file "logs_integrations_mysql" {
+      targets    = local.file_match.logs_integrations_mysql.targets
+      forward_to = [loki.process.logs_integrations_mysql.receiver]
+    }
+
+    prometheus.remote_write "metrics_service" {
+      endpoint {
+        url = "{{prom_url}}"
+
+        {% if prom_user and prom_pass -%}
+        basic_auth {
+          username = "{{prom_user}}"
+          password = "{{prom_pass}}"
+        }
+        {%- endif %}
+
+        queue_config { }
+
+        metadata_config { }
+      }
+    }
+
+    local.file "mysql_secret" {
+      filename = "/var/lib/grafana-agent-flow/mysql-secret"
+      is_secret = true
+    }
+
+    prometheus.exporter.mysql "integrations_mysqld_exporter" {
+      data_source_name = local.file.mysql_secret.content
+    }
+
+    discovery.relabel "integrations_mysqld_exporter" {
+      targets = prometheus.exporter.mysql.integrations_mysqld_exporter.targets
+
+      rule {
+        target_label = "job"
+        replacement  = "integrations/mysql"
+      }
+
+      rule {
+        target_label = "instance"
+        replacement  = constants.hostname
+      }
+    }
+
+    prometheus.scrape "integrations_mysqld_exporter" {
+      targets    = discovery.relabel.integrations_mysqld_exporter.output
+      forward_to = [prometheus.remote_write.metrics_service.receiver]
+      job_name   = "integrations/mysqld_exporter"
+    }


### PR DESCRIPTION
Adds a MySQL Sample App.

Like the other multipass VM based sample apps, it configures a local flow agent to write to the specified loki and prometheus/mimir endpoints. 