### PR TITLE
Add Catchpoint sample

### DIFF
--- a/catchpoint/.gitignore
+++ b/catchpoint/.gitignore
@@ -1,0 +1,2 @@
+cloud-init.yaml
+generated_configs/

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -1,0 +1,51 @@
+VM_NAME := catchpoint
+K8S_NAMESPACE := default
+CONFIG_FILE := jinja/variables/cloud-init.yaml
+TEMPLATE_DIR := jinja/templates
+OUTPUT_DIR := generated_configs
+GRAFANA_FLOW_VALUES := $(OUTPUT_DIR)/grafana-flow-k8s-template.yaml
+
+.PHONY: run-catchpoint-multipass
+run-catchpoint-multipass:
+	@multipass launch -n $(VM_NAME) --memory 14G --disk 10G --cpus 4
+	@multipass mount ./generated_configs/ $(VM_NAME):/catchpoint/config
+	@multipass mount ./scripts $(VM_NAME):/catchpoint/scripts
+	@multipass exec $(VM_NAME) -- bash /catchpoint/scripts/setup_docker.sh
+	@multipass stop $(VM_NAME)
+	@multipass start $(VM_NAME)
+	@multipass exec $(VM_NAME) -- bash /catchpoint/scripts/init_script.sh
+
+.PHONY: stop-catchpoint-multipass
+stop-catchpoint-multipass:
+	@multipass stop $(VM_NAME)
+	@multipass delete $(VM_NAME)
+	@sleep 10
+	@multipass purge
+
+render-config:
+	python3 scripts/render_template.py --config_file $(CONFIG_FILE) --template_dir $(TEMPLATE_DIR) --output_dir $(OUTPUT_DIR)
+	@echo "Config templates rendered."
+
+clean:
+	@echo "Cleaning generated configs..."
+	@rm -f cloud-init.yaml
+	@rm -rf $(OUTPUT_DIR)/*
+	@echo "Generated configs cleaned."
+
+defaultconfig:
+	@echo "exporter_repo: https://github.com/yourgithub/catchpoint-prometheus-exporter.git" > jinja/variables/cloud-init.yaml
+	@echo "exporter_dir: catchpoint-prometheus-exporter" >> jinja/variables/cloud-init.yaml
+	@echo "prom_addr: \":8080\"" >> jinja/variables/cloud-init.yaml
+	@echo "catchpoint_bearer_token: \"your_token\"" >> jinja/variables/cloud-init.yaml
+	@echo "node_ids: \"1,2\"" >> jinja/variables/cloud-init.yaml
+	@echo "interval: \"10s\"" >> jinja/variables/cloud-init.yaml
+	@echo "loki_url: http://your-loki-instance:3100/loki/api/v1/push" >> jinja/variables/cloud-init.yaml
+	@echo "loki_user: your_loki_username" >> jinja/variables/cloud-init.yaml
+	@echo "loki_pass: your_loki_password" >> jinja/variables/cloud-init.yaml
+	@echo "prom_url: http://your-prometheus-instance:9090/api/v1/push" >> jinja/variables/cloud-init.yaml
+	@echo "prom_user: your_prometheus_username" >> jinja/variables/cloud-init.yaml
+	@echo "prom_pass: your_prometheus_password" >> jinja/variables/cloud-init.yaml
+	@echo "prom_port: 8080" >> jinja/variables/cloud-init.yaml
+
+fetch-prometheus-metrics:
+	@multipass exec $(VM_NAME) -- curl http://localhost:8080/metrics > prometheus_metrics

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -51,8 +51,6 @@ clean:
 
 .PHONY: defaultconfig
 defaultconfig:
-	@echo "loki_user: your_loki_username" >> jinja/variables/cloud-init.yaml
-	@echo "loki_pass: your_loki_password" >> jinja/variables/cloud-init.yaml
 	@echo "prom_user: your_prometheus_username" >> jinja/variables/cloud-init.yaml
 	@echo "prom_pass: your_prometheus_password" >> jinja/variables/cloud-init.yaml
 

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -51,6 +51,7 @@ clean:
 
 .PHONY: defaultconfig
 defaultconfig:
+	@echo "prom_host: https://prometheus-us-central1.grafana.net" >> jinja/variables/cloud-init.yaml
 	@echo "prom_user: your_prometheus_username" >> jinja/variables/cloud-init.yaml
 	@echo "prom_pass: your_prometheus_password" >> jinja/variables/cloud-init.yaml
 

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -43,7 +43,7 @@ render-config:
 	@echo "Config templates rendered."
 
 .PHONY: clean
-clean:
+clean: stop-catchpoint-multipass
 	@echo "Cleaning generated configs..."
 	@rm -f cloud-init.yaml
 	@rm -rf $(OUTPUT_DIR)/*

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -27,7 +27,7 @@ port-forward:
 	@echo "Setting kubectl context to minikube"
 	@multipass exec $(VM_NAME) -- bash -c "kubectl config use-context minikube"
 	@echo "Starting port-forwarding for Prometheus exporter"
-	@multipass exec $(VM_NAME) -- bash -c "kubectl --context=minikube -n $(K8S_NAMESPACE) port-forward svc/catchpoint-exporter 9090:9090 &"
+	@multipass exec $(VM_NAME) -- bash -c "tmux new-session -d -s port-forward 'kubectl port-forward svc/catchpoint-exporter 9090:9090'"
 	@sleep 5 # Wait a few seconds to ensure port-forwarding is established
 	@echo "Port-forwarding enabled for Prometheus exporter."
 
@@ -51,16 +51,10 @@ clean:
 
 .PHONY: defaultconfig
 defaultconfig:
-	@echo "exporter_repo: https://github.com/grafana/catchpoint-prometheus-exporter.git" > jinja/variables/cloud-init.yaml
-	@echo "exporter_dir: catchpoint-prometheus-exporter" >> jinja/variables/cloud-init.yaml
-	@echo "prom_addr: \":9090\"" >> jinja/variables/cloud-init.yaml
-	@echo "loki_url: http://your-loki-instance:3100/loki/api/v1/push" >> jinja/variables/cloud-init.yaml
 	@echo "loki_user: your_loki_username" >> jinja/variables/cloud-init.yaml
 	@echo "loki_pass: your_loki_password" >> jinja/variables/cloud-init.yaml
-	@echo "prom_url: http://your-prometheus-instance:9090/api/v1/push" >> jinja/variables/cloud-init.yaml
 	@echo "prom_user: your_prometheus_username" >> jinja/variables/cloud-init.yaml
 	@echo "prom_pass: your_prometheus_password" >> jinja/variables/cloud-init.yaml
-	@echo "prom_port: 9090" >> jinja/variables/cloud-init.yaml
 
 .PHONY: fetch-prometheus-metrics
 fetch-prometheus-metrics:

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -51,6 +51,8 @@ clean:
 
 .PHONY: defaultconfig
 defaultconfig:
+	@echo "loki_user: your_loki_username" >> jinja/variables/cloud-init.yaml
+	@echo "loki_pass: your_loki_password" >> jinja/variables/cloud-init.yaml
 	@echo "prom_host: https://prometheus-us-central1.grafana.net" >> jinja/variables/cloud-init.yaml
 	@echo "prom_user: your_prometheus_username" >> jinja/variables/cloud-init.yaml
 	@echo "prom_pass: your_prometheus_password" >> jinja/variables/cloud-init.yaml

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -1,51 +1,70 @@
-VM_NAME := catchpoint
-K8S_NAMESPACE := default
-CONFIG_FILE := jinja/variables/cloud-init.yaml
-TEMPLATE_DIR := jinja/templates
-OUTPUT_DIR := generated_configs
-GRAFANA_FLOW_VALUES := $(OUTPUT_DIR)/grafana-flow-k8s-template.yaml
+# Catchpoint Exporter with Multipass
 
-.PHONY: run-catchpoint-multipass
-run-catchpoint-multipass:
-	@multipass launch -n $(VM_NAME) --memory 14G --disk 10G --cpus 4
-	@multipass mount ./generated_configs/ $(VM_NAME):/catchpoint/config
-	@multipass mount ./scripts $(VM_NAME):/catchpoint/scripts
-	@multipass exec $(VM_NAME) -- bash /catchpoint/scripts/setup_docker.sh
-	@multipass stop $(VM_NAME)
-	@multipass start $(VM_NAME)
-	@multipass exec $(VM_NAME) -- bash /catchpoint/scripts/init_script.sh
+This sample application sets up a Catchpoint Exporter in a VM environment using Multipass, integrated with Grafana Flow/Alloy for metric collection. This setup uses cloud-init and Make commands to facilitate the configuration and monitoring of the Catchpoint Exporter instance.
 
-.PHONY: stop-catchpoint-multipass
-stop-catchpoint-multipass:
-	@multipass stop $(VM_NAME)
-	@multipass delete $(VM_NAME)
-	@sleep 10
-	@multipass purge
+*Note*: To ensure a working Catchpoint Exporter instance, sufficient memory and CPU resources are allocated to each VM.
 
-render-config:
-	python3 scripts/render_template.py --config_file $(CONFIG_FILE) --template_dir $(TEMPLATE_DIR) --output_dir $(OUTPUT_DIR)
-	@echo "Config templates rendered."
+## Prerequisites
 
-clean:
-	@echo "Cleaning generated configs..."
-	@rm -f cloud-init.yaml
-	@rm -rf $(OUTPUT_DIR)/*
-	@echo "Generated configs cleaned."
+Before you begin, ensure you have the following installed:
 
-defaultconfig:
-	@echo "exporter_repo: https://github.com/yourgithub/catchpoint-prometheus-exporter.git" > jinja/variables/cloud-init.yaml
-	@echo "exporter_dir: catchpoint-prometheus-exporter" >> jinja/variables/cloud-init.yaml
-	@echo "prom_addr: \":8080\"" >> jinja/variables/cloud-init.yaml
-	@echo "catchpoint_bearer_token: \"your_token\"" >> jinja/variables/cloud-init.yaml
-	@echo "node_ids: \"1,2\"" >> jinja/variables/cloud-init.yaml
-	@echo "interval: \"10s\"" >> jinja/variables/cloud-init.yaml
-	@echo "loki_url: http://your-loki-instance:3100/loki/api/v1/push" >> jinja/variables/cloud-init.yaml
-	@echo "loki_user: your_loki_username" >> jinja/variables/cloud-init.yaml
-	@echo "loki_pass: your_loki_password" >> jinja/variables/cloud-init.yaml
-	@echo "prom_url: http://your-prometheus-instance:9090/api/v1/push" >> jinja/variables/cloud-init.yaml
-	@echo "prom_user: your_prometheus_username" >> jinja/variables/cloud-init.yaml
-	@echo "prom_pass: your_prometheus_password" >> jinja/variables/cloud-init.yaml
-	@echo "prom_port: 8080" >> jinja/variables/cloud-init.yaml
+- [Multipass](https://multipass.run/)
+- Docker (for building images and rendering cloud-init configurations)
+- Git (for version control and repository management)
+- Catchpoint setup to collect metrics from the [Prometheus exporter](https://github.com/grafana/catchpoint-prometheus-exporter/blob/main/README.md)
 
-fetch-prometheus-metrics:
-	@multipass exec $(VM_NAME) -- curl http://localhost:8080/metrics > prometheus_metrics
+## Platform Support
+Currently, this sample app supports ARM64 and amd64 platforms.
+
+## Quick Start for New Users
+
+To get started with the Catchpoint Exporter along with monitoring tools, follow these steps:
+
+1. **Clone the Repository**: 
+   ```sh
+   git clone https://github.com/grafana/integration-sample-apps.git
+   cd integration-sample-apps/catchpoint
+   ```
+
+2. **Set Up Default Config**: 
+   Execute `make defaultconfig` to create a template file with default configuration variables. Modify `jinja/variables/cloud-init.yaml` to configure Grafana flow to connect to an external Prometheus instance.
+
+3. **Render Cloud-init Configuration**: 
+   Run `make render-config` to generate the `cloud-init.yaml` file based on your configuration.
+
+4. **Create and Set Up VMs**: 
+   Use `make run-catchpoint-multipass` to start VMs with the Catchpoint Exporter.
+
+5. **Port-Forward and Run Load Generation**:
+   Start port-forwarding and generate load by running `make port-forward` followed by `make run-metrics`. This will forward the necessary ports and run the `post_metrics.py` script to generate load.
+
+6. **Fetch Prometheus Metrics**: 
+   Fetch metrics from the Prometheus exporter and save them with `make fetch-prometheus-metrics`.
+
+7. **Stop and Clean Up**: 
+   Use `make stop-catchpoint-multipass` to clean up the VM and `make clean` to remove temporary files.
+
+## Make Commands
+
+- `make defaultconfig`: Initializes the configuration file with default values for cloud-init templates.
+- `make render-config`: Generates the `cloud-init.yaml` configuration file using the defined variables.
+- `make run-catchpoint-multipass`: Creates VMs and sets up the Catchpoint Exporter.
+- `make port-forward`: Starts port-forwarding for the Prometheus exporter.
+- `make run-metrics`: Runs the `post_metrics.py` script to generate load.
+- `make fetch-prometheus-metrics`: Fetches metrics from the Prometheus exporter and saves them to a local file.
+- `make clean`: Deletes all created VMs and performs cleanup.
+
+## Default Configuration Variables
+
+The following are the default variables used in the `cloud-init.yaml` file:
+
+- `exporter_repo`: Repository URL for the Catchpoint Exporter.
+- `exporter_dir`: Directory name for the Catchpoint Exporter.
+- `prom_addr`: Prometheus address (e.g., `":9090"`).
+- `loki_url`: URL for Loki push endpoint.
+- `loki_user`: Your Loki username.
+- `loki_pass`: Your Loki password.
+- `prom_url`: URL for Prometheus push endpoint.
+- `prom_user`: Your Prometheus username.
+- `prom_pass`: Your Prometheus password.
+- `prom_port`: Prometheus port.

--- a/catchpoint/Makefile
+++ b/catchpoint/Makefile
@@ -1,70 +1,71 @@
-# Catchpoint Exporter with Multipass
+VM_NAME := catchpoint
+K8S_NAMESPACE := default
+CONFIG_FILE := jinja/variables/cloud-init.yaml
+TEMPLATE_DIR := jinja/templates
+OUTPUT_DIR := generated_configs
+GRAFANA_FLOW_VALUES := $(OUTPUT_DIR)/grafana-flow-k8s-template.yaml
 
-This sample application sets up a Catchpoint Exporter in a VM environment using Multipass, integrated with Grafana Flow/Alloy for metric collection. This setup uses cloud-init and Make commands to facilitate the configuration and monitoring of the Catchpoint Exporter instance.
+.PHONY: run-catchpoint-multipass
+run-catchpoint-multipass: render-config
+	@multipass launch -n $(VM_NAME) --memory 14G --disk 10G --cpus 4
+	@multipass mount ./generated_configs/ $(VM_NAME):/catchpoint/config
+	@multipass mount ./scripts $(VM_NAME):/catchpoint/scripts
+	@multipass exec $(VM_NAME) -- bash /catchpoint/scripts/setup_docker.sh
+	@multipass stop $(VM_NAME)
+	@multipass start $(VM_NAME)
+	@multipass exec $(VM_NAME) -- bash /catchpoint/scripts/init_script.sh
 
-*Note*: To ensure a working Catchpoint Exporter instance, sufficient memory and CPU resources are allocated to each VM.
+.PHONY: stop-catchpoint-multipass
+stop-catchpoint-multipass:
+	@multipass stop $(VM_NAME)
+	@multipass delete $(VM_NAME)
+	@sleep 10
+	@multipass purge
 
-## Prerequisites
+.PHONY: port-forward
+port-forward:
+	@echo "Setting kubectl context to minikube"
+	@multipass exec $(VM_NAME) -- bash -c "kubectl config use-context minikube"
+	@echo "Starting port-forwarding for Prometheus exporter"
+	@multipass exec $(VM_NAME) -- bash -c "kubectl --context=minikube -n $(K8S_NAMESPACE) port-forward svc/catchpoint-exporter 9090:9090 &"
+	@sleep 5 # Wait a few seconds to ensure port-forwarding is established
+	@echo "Port-forwarding enabled for Prometheus exporter."
 
-Before you begin, ensure you have the following installed:
+.PHONY: run-metrics
+run-metrics:
+	@echo "Running post_metrics.py script"
+	@multipass exec $(VM_NAME) -- python3 /catchpoint/scripts/post_metrics.py
+	@echo "Metrics script executed."
 
-- [Multipass](https://multipass.run/)
-- Docker (for building images and rendering cloud-init configurations)
-- Git (for version control and repository management)
-- Catchpoint setup to collect metrics from the [Prometheus exporter](https://github.com/grafana/catchpoint-prometheus-exporter/blob/main/README.md)
+.PHONY: render-config
+render-config:
+	python3 scripts/render_template.py --config_file $(CONFIG_FILE) --template_dir $(TEMPLATE_DIR) --output_dir $(OUTPUT_DIR)
+	@echo "Config templates rendered."
 
-## Platform Support
-Currently, this sample app supports ARM64 and amd64 platforms.
+.PHONY: clean
+clean:
+	@echo "Cleaning generated configs..."
+	@rm -f cloud-init.yaml
+	@rm -rf $(OUTPUT_DIR)/*
+	@echo "Generated configs cleaned."
 
-## Quick Start for New Users
+.PHONY: defaultconfig
+defaultconfig:
+	@echo "exporter_repo: https://github.com/grafana/catchpoint-prometheus-exporter.git" > jinja/variables/cloud-init.yaml
+	@echo "exporter_dir: catchpoint-prometheus-exporter" >> jinja/variables/cloud-init.yaml
+	@echo "prom_addr: \":9090\"" >> jinja/variables/cloud-init.yaml
+	@echo "loki_url: http://your-loki-instance:3100/loki/api/v1/push" >> jinja/variables/cloud-init.yaml
+	@echo "loki_user: your_loki_username" >> jinja/variables/cloud-init.yaml
+	@echo "loki_pass: your_loki_password" >> jinja/variables/cloud-init.yaml
+	@echo "prom_url: http://your-prometheus-instance:9090/api/v1/push" >> jinja/variables/cloud-init.yaml
+	@echo "prom_user: your_prometheus_username" >> jinja/variables/cloud-init.yaml
+	@echo "prom_pass: your_prometheus_password" >> jinja/variables/cloud-init.yaml
+	@echo "prom_port: 9090" >> jinja/variables/cloud-init.yaml
 
-To get started with the Catchpoint Exporter along with monitoring tools, follow these steps:
+.PHONY: fetch-prometheus-metrics
+fetch-prometheus-metrics:
+	@multipass exec $(VM_NAME) -- curl http://localhost:9090/metrics > prometheus_metrics
 
-1. **Clone the Repository**: 
-   ```sh
-   git clone https://github.com/grafana/integration-sample-apps.git
-   cd integration-sample-apps/catchpoint
-   ```
-
-2. **Set Up Default Config**: 
-   Execute `make defaultconfig` to create a template file with default configuration variables. Modify `jinja/variables/cloud-init.yaml` to configure Grafana flow to connect to an external Prometheus instance.
-
-3. **Render Cloud-init Configuration**: 
-   Run `make render-config` to generate the `cloud-init.yaml` file based on your configuration.
-
-4. **Create and Set Up VMs**: 
-   Use `make run-catchpoint-multipass` to start VMs with the Catchpoint Exporter.
-
-5. **Port-Forward and Run Load Generation**:
-   Start port-forwarding and generate load by running `make port-forward` followed by `make run-metrics`. This will forward the necessary ports and run the `post_metrics.py` script to generate load.
-
-6. **Fetch Prometheus Metrics**: 
-   Fetch metrics from the Prometheus exporter and save them with `make fetch-prometheus-metrics`.
-
-7. **Stop and Clean Up**: 
-   Use `make stop-catchpoint-multipass` to clean up the VM and `make clean` to remove temporary files.
-
-## Make Commands
-
-- `make defaultconfig`: Initializes the configuration file with default values for cloud-init templates.
-- `make render-config`: Generates the `cloud-init.yaml` configuration file using the defined variables.
-- `make run-catchpoint-multipass`: Creates VMs and sets up the Catchpoint Exporter.
-- `make port-forward`: Starts port-forwarding for the Prometheus exporter.
-- `make run-metrics`: Runs the `post_metrics.py` script to generate load.
-- `make fetch-prometheus-metrics`: Fetches metrics from the Prometheus exporter and saves them to a local file.
-- `make clean`: Deletes all created VMs and performs cleanup.
-
-## Default Configuration Variables
-
-The following are the default variables used in the `cloud-init.yaml` file:
-
-- `exporter_repo`: Repository URL for the Catchpoint Exporter.
-- `exporter_dir`: Directory name for the Catchpoint Exporter.
-- `prom_addr`: Prometheus address (e.g., `":9090"`).
-- `loki_url`: URL for Loki push endpoint.
-- `loki_user`: Your Loki username.
-- `loki_pass`: Your Loki password.
-- `prom_url`: URL for Prometheus push endpoint.
-- `prom_user`: Your Prometheus username.
-- `prom_pass`: Your Prometheus password.
-- `prom_port`: Prometheus port.
+.PHONY: all
+all: run-catchpoint-multipass port-forward run-metrics
+	@echo "All tasks completed."

--- a/catchpoint/README.md
+++ b/catchpoint/README.md
@@ -55,5 +55,6 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
 
 The following are the default variables used in the `cloud-init.yaml` file:
 
+- `prom_host`: Your Prometheus host (Default https://prometheus-us-central1.grafana.net).
 - `prom_user`: Your Prometheus username.
 - `prom_pass`: Your Prometheus password.

--- a/catchpoint/README.md
+++ b/catchpoint/README.md
@@ -1,0 +1,67 @@
+# Catchpoint Exporter with Multipass
+
+This sample application sets up a Catchpoint Exporter in a VM environment using Multipass, integrated with Grafana Flow/Alloy for metric collection. This setup uses cloud-init and Make commands to facilitate the configuration and monitoring of the Catchpoint Exporter instance.
+
+*Note*: To ensure a working Catchpoint Exporter instance, sufficient memory and CPU resources are allocated to each VM.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+- [Multipass](https://multipass.run/)
+- Docker (for building images and rendering cloud-init configurations)
+- Git (for version control and repository management)
+
+## Platform Support
+Currently, this sample app supports ARM64 and amd64 platforms.
+
+## Quick Start for New Users
+
+To get started with the Catchpoint Exporter along with monitoring tools, follow these steps:
+
+1. **Clone the Repository**: 
+   ```sh
+   git clone https://github.com/grafana/integration-sample-apps.git
+   cd integration-sample-apps/catchpoint
+   ```
+
+2. **Set Up Default Config**: 
+   Execute `make defaultconfig` to create a template file with default configuration variables. Modify `jinja/variables/cloud-init.yaml` to configure Grafana flow to connect to an external Prometheus instance.
+
+3. **Render Cloud-init Configuration**: 
+   Run `make render-config` to generate the `cloud-init.yaml` file based on your configuration.
+
+4. **Create and Set Up VMs**: 
+   Use `make run-catchpoint-multipass` to start VMs with the Catchpoint Exporter.
+
+5. **Fetch Prometheus Metrics**: 
+   Fetch metrics from the Prometheus exporter and save them with `make fetch-prometheus-metrics`.
+
+6. **Stop and Clean Up**: 
+   Use `make stop-catchpoint-multipass` to clean up the VM and `make clean` to remove temporary files.
+
+## Make Commands
+
+- `make defaultconfig`: Initializes the configuration file with default values for cloud-init templates.
+- `make render-config`: Generates the `cloud-init.yaml` configuration file using the defined variables.
+- `make run-catchpoint-multipass`: Creates VMs and sets up the Catchpoint Exporter.
+- `make fetch-prometheus-metrics`: Fetches metrics from the Prometheus exporter and saves them to a local file.
+- `make clean`: Deletes all created VMs and performs cleanup.
+
+## Default Configuration Variables
+
+The following are the default variables used in the `cloud-init.yaml` file:
+
+- `exporter_repo`: Repository URL for the Catchpoint Exporter.
+- `exporter_dir`: Directory name for the Catchpoint Exporter.
+- `prom_addr`: Prometheus address (e.g., `":8080"`).
+- `catchpoint_bearer_token`: Your Catchpoint bearer token.
+- `node_ids`: Node IDs for Catchpoint.
+- `interval`: Polling interval.
+- `loki_url`: URL for Loki push endpoint.
+- `loki_user`: Your Loki username.
+- `loki_pass`: Your Loki password.
+- `prom_url`: URL for Prometheus push endpoint.
+- `prom_user`: Your Prometheus username.
+- `prom_pass`: Your Prometheus password.
+- `prom_port`: Prometheus port.

--- a/catchpoint/README.md
+++ b/catchpoint/README.md
@@ -55,7 +55,5 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
 
 The following are the default variables used in the `cloud-init.yaml` file:
 
-- `loki_user`: Your Loki username.
-- `loki_pass`: Your Loki password.
 - `prom_user`: Your Prometheus username.
 - `prom_pass`: Your Prometheus password.

--- a/catchpoint/README.md
+++ b/catchpoint/README.md
@@ -11,6 +11,7 @@ Before you begin, ensure you have the following installed:
 - [Multipass](https://multipass.run/)
 - Docker (for building images and rendering cloud-init configurations)
 - Git (for version control and repository management)
+- Catchpoint setup to collect metrics from the [Prometheus exporter](https://github.com/grafana/catchpoint-prometheus-exporter/blob/main/README.md)
 
 ## Platform Support
 Currently, this sample app supports ARM64 and amd64 platforms.
@@ -54,10 +55,7 @@ The following are the default variables used in the `cloud-init.yaml` file:
 
 - `exporter_repo`: Repository URL for the Catchpoint Exporter.
 - `exporter_dir`: Directory name for the Catchpoint Exporter.
-- `prom_addr`: Prometheus address (e.g., `":8080"`).
-- `catchpoint_bearer_token`: Your Catchpoint bearer token.
-- `node_ids`: Node IDs for Catchpoint.
-- `interval`: Polling interval.
+- `prom_addr`: Prometheus address (e.g., `":9090"`).
 - `loki_url`: URL for Loki push endpoint.
 - `loki_user`: Your Loki username.
 - `loki_pass`: Your Loki password.
@@ -65,3 +63,4 @@ The following are the default variables used in the `cloud-init.yaml` file:
 - `prom_user`: Your Prometheus username.
 - `prom_pass`: Your Prometheus password.
 - `prom_port`: Prometheus port.
+

--- a/catchpoint/README.md
+++ b/catchpoint/README.md
@@ -1,6 +1,6 @@
 # Catchpoint Exporter with Multipass
 
-This sample application sets up a Catchpoint Exporter in a VM environment using Multipass, integrated with Grafana Flow/Alloy for metric collection. This setup uses cloud-init and Make commands to facilitate the configuration and monitoring of the Catchpoint Exporter instance.
+This sample application sets up a Catchpoint Exporter in a VM environment using Multipass, integrated with Grafana Flow/Alloy for metric collection. This setup uses cloud-init and Make commands to facilitate the configuration and monitoring of the Catchpoint Exporter instance using mock generated load.
 
 *Note*: To ensure a working Catchpoint Exporter instance, sufficient memory and CPU resources are allocated to each VM.
 
@@ -35,10 +35,13 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
 4. **Create and Set Up VMs**: 
    Use `make run-catchpoint-multipass` to start VMs with the Catchpoint Exporter.
 
-5. **Fetch Prometheus Metrics**: 
+5. **Port-Forward and Run Load Generation**:
+   Start port-forwarding and generate load by running `make port-forward` followed by `make run-metrics`. This will forward the necessary ports and run the `post_metrics.py` script to generate load.
+
+6. **Fetch Prometheus Metrics**: 
    Fetch metrics from the Prometheus exporter and save them with `make fetch-prometheus-metrics`.
 
-6. **Stop and Clean Up**: 
+7. **Stop and Clean Up**: 
    Use `make stop-catchpoint-multipass` to clean up the VM and `make clean` to remove temporary files.
 
 ## Make Commands
@@ -46,6 +49,8 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
 - `make defaultconfig`: Initializes the configuration file with default values for cloud-init templates.
 - `make render-config`: Generates the `cloud-init.yaml` configuration file using the defined variables.
 - `make run-catchpoint-multipass`: Creates VMs and sets up the Catchpoint Exporter.
+- `make port-forward`: Starts port-forwarding for the Prometheus exporter.
+- `make run-metrics`: Runs the `post_metrics.py` script to generate load.
 - `make fetch-prometheus-metrics`: Fetches metrics from the Prometheus exporter and saves them to a local file.
 - `make clean`: Deletes all created VMs and performs cleanup.
 
@@ -63,4 +68,3 @@ The following are the default variables used in the `cloud-init.yaml` file:
 - `prom_user`: Your Prometheus username.
 - `prom_pass`: Your Prometheus password.
 - `prom_port`: Prometheus port.
-

--- a/catchpoint/README.md
+++ b/catchpoint/README.md
@@ -55,6 +55,8 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
 
 The following are the default variables used in the `cloud-init.yaml` file:
 
+- `loki_user`: Your Loki username.
+- `loki_pass`: Your Loki password.
 - `prom_host`: Your Prometheus host (Default https://prometheus-us-central1.grafana.net).
 - `prom_user`: Your Prometheus username.
 - `prom_pass`: Your Prometheus password.

--- a/catchpoint/README.md
+++ b/catchpoint/README.md
@@ -25,23 +25,19 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
    git clone https://github.com/grafana/integration-sample-apps.git
    cd integration-sample-apps/catchpoint
    ```
-
 2. **Set Up Default Config**: 
    Execute `make defaultconfig` to create a template file with default configuration variables. Modify `jinja/variables/cloud-init.yaml` to configure Grafana flow to connect to an external Prometheus instance.
 
-3. **Render Cloud-init Configuration**: 
-   Run `make render-config` to generate the `cloud-init.yaml` file based on your configuration.
+3. **Create and Set Up VMs**: 
+   Use `make run-catchpoint-multipass` to start VMs with the Catchpoint Exporter. Optionally, instead use `make all` to port-forward and run the load generation together which is step 4.
 
-4. **Create and Set Up VMs**: 
-   Use `make run-catchpoint-multipass` to start VMs with the Catchpoint Exporter.
-
-5. **Port-Forward and Run Load Generation**:
+4. **Port-Forward and Run Load Generation**:
    Start port-forwarding and generate load by running `make port-forward` followed by `make run-metrics`. This will forward the necessary ports and run the `post_metrics.py` script to generate load.
 
-6. **Fetch Prometheus Metrics**: 
+5. **Fetch Prometheus Metrics**: 
    Fetch metrics from the Prometheus exporter and save them with `make fetch-prometheus-metrics`.
 
-7. **Stop and Clean Up**: 
+6. **Stop and Clean Up**: 
    Use `make stop-catchpoint-multipass` to clean up the VM and `make clean` to remove temporary files.
 
 ## Make Commands
@@ -51,6 +47,7 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
 - `make run-catchpoint-multipass`: Creates VMs and sets up the Catchpoint Exporter.
 - `make port-forward`: Starts port-forwarding for the Prometheus exporter.
 - `make run-metrics`: Runs the `post_metrics.py` script to generate load.
+- `make all`: Combines `run-catchpoint-multipass` `port-forward` and `run-metrics`.
 - `make fetch-prometheus-metrics`: Fetches metrics from the Prometheus exporter and saves them to a local file.
 - `make clean`: Deletes all created VMs and performs cleanup.
 
@@ -58,13 +55,7 @@ To get started with the Catchpoint Exporter along with monitoring tools, follow 
 
 The following are the default variables used in the `cloud-init.yaml` file:
 
-- `exporter_repo`: Repository URL for the Catchpoint Exporter.
-- `exporter_dir`: Directory name for the Catchpoint Exporter.
-- `prom_addr`: Prometheus address (e.g., `":9090"`).
-- `loki_url`: URL for Loki push endpoint.
 - `loki_user`: Your Loki username.
 - `loki_pass`: Your Loki password.
-- `prom_url`: URL for Prometheus push endpoint.
 - `prom_user`: Your Prometheus username.
 - `prom_pass`: Your Prometheus password.
-- `prom_port`: Prometheus port.

--- a/catchpoint/jinja/templates/catchpoint-exporter-deployment.yaml.j2
+++ b/catchpoint/jinja/templates/catchpoint-exporter-deployment.yaml.j2
@@ -16,6 +16,5 @@ spec:
       - name: catchpoint-exporter
         image: jonnywamsley/catchpoint-exporter:latest
         imagePullPolicy: Always
-        args: ["--bearer-token={{ catchpoint_bearer_token }}", "--node-ids={{ node_ids }}"]
         ports:
-        - containerPort: 8080
+        - containerPort: 9090

--- a/catchpoint/jinja/templates/catchpoint-exporter-deployment.yaml.j2
+++ b/catchpoint/jinja/templates/catchpoint-exporter-deployment.yaml.j2
@@ -15,6 +15,7 @@ spec:
       containers:
       - name: catchpoint-exporter
         image: jonnywamsley/catchpoint-exporter:latest
+        args: ["--port=9090", "--webhook-path=/webhook", "--verbose"]
         imagePullPolicy: Always
         ports:
         - containerPort: 9090

--- a/catchpoint/jinja/templates/catchpoint-exporter-deployment.yaml.j2
+++ b/catchpoint/jinja/templates/catchpoint-exporter-deployment.yaml.j2
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catchpoint-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catchpoint-exporter
+  template:
+    metadata:
+      labels:
+        app: catchpoint-exporter
+    spec:
+      containers:
+      - name: catchpoint-exporter
+        image: jonnywamsley/catchpoint-exporter:latest
+        imagePullPolicy: Always
+        args: ["--bearer-token={{ catchpoint_bearer_token }}", "--node-ids={{ node_ids }}"]
+        ports:
+        - containerPort: 8080

--- a/catchpoint/jinja/templates/catchpoint-exporter-service.yaml.j2
+++ b/catchpoint/jinja/templates/catchpoint-exporter-service.yaml.j2
@@ -7,8 +7,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 8080
-    targetPort: 8080
+  - port: 9090
+    targetPort: 9090
     protocol: TCP
   selector:
     app: catchpoint-exporter

--- a/catchpoint/jinja/templates/catchpoint-exporter-service.yaml.j2
+++ b/catchpoint/jinja/templates/catchpoint-exporter-service.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: catchpoint-exporter
+  labels:
+    app: catchpoint-exporter
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: catchpoint-exporter

--- a/catchpoint/jinja/templates/grafana-flow-k8s-template.yaml.j2
+++ b/catchpoint/jinja/templates/grafana-flow-k8s-template.yaml.j2
@@ -8,6 +8,11 @@ externalServices:
     basicAuth:
       username: "{{ prom_user }}"
       password: "{{ prom_pass }}"
+  loki:
+    host: "https://logs-prod3.grafana.net"
+    basicAuth:
+      username: "{{ loki_user }}"
+      password: "{{ loki_pass }}"
 
 extraConfig: |-
   discovery.relabel "catchpoint" {

--- a/catchpoint/jinja/templates/grafana-flow-k8s-template.yaml.j2
+++ b/catchpoint/jinja/templates/grafana-flow-k8s-template.yaml.j2
@@ -4,15 +4,10 @@ cluster:
 
 externalServices:
   prometheus:
-    host: "https://prometheus-us-central1.grafana.net"
+    host: "{{ prom_host }}"
     basicAuth:
       username: "{{ prom_user }}"
       password: "{{ prom_pass }}"
-  loki:
-    host: "https://logs-prod3.grafana.net"
-    basicAuth:
-      username: "{{ loki_user }}"
-      password: "{{ loki_pass }}"
 
 extraConfig: |-
   discovery.relabel "catchpoint" {

--- a/catchpoint/jinja/templates/grafana-flow-k8s-template.yaml.j2
+++ b/catchpoint/jinja/templates/grafana-flow-k8s-template.yaml.j2
@@ -1,0 +1,40 @@
+# jinja/templates/grafana-flow-k8s-template.yaml.j2:
+cluster:
+  name: "catchpoint-cluster"
+
+externalServices:
+  prometheus:
+    host: "https://prometheus-us-central1.grafana.net"
+    basicAuth:
+      username: "{{ prom_user }}"
+      password: "{{ prom_pass }}"
+  loki:
+    host: "https://logs-prod3.grafana.net"
+    basicAuth:
+      username: "{{ loki_user }}"
+      password: "{{ loki_pass }}"
+
+extraConfig: |-
+  discovery.relabel "catchpoint" {
+    targets = discovery.kubernetes.endpoints.targets
+    rule {
+      action        = "keep"
+      source_labels = ["__meta_kubernetes_service_name"]
+      regex         = "catchpoint-exporter"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+      separator = "-"
+      target_label = "instance"
+    }
+    rule {
+      replacement = "integrations/catchpoint"
+      target_label = "job"
+    }
+  }
+
+  prometheus.scrape "catchpoint" {
+    targets      = discovery.relabel.catchpoint.output
+    forward_to   = [prometheus.relabel.metrics_service.receiver]
+  }
+

--- a/catchpoint/jinja/variables/cloud-init.yaml
+++ b/catchpoint/jinja/variables/cloud-init.yaml
@@ -1,0 +1,4 @@
+loki_user: your_loki_username
+loki_pass: your_loki_password
+prom_user: your_prometheus_username
+prom_pass: your_prometheus_password

--- a/catchpoint/jinja/variables/cloud-init.yaml
+++ b/catchpoint/jinja/variables/cloud-init.yaml
@@ -1,3 +1,5 @@
+loki_user: your_loki_username
+loki_pass: your_loki_password
 prom_host: https://prometheus-us-central1.grafana.net
 prom_user: your_prometheus_username
 prom_pass: your_prometheus_password

--- a/catchpoint/jinja/variables/cloud-init.yaml
+++ b/catchpoint/jinja/variables/cloud-init.yaml
@@ -1,4 +1,2 @@
-loki_user: your_loki_username
-loki_pass: your_loki_password
 prom_user: your_prometheus_username
 prom_pass: your_prometheus_password

--- a/catchpoint/jinja/variables/cloud-init.yaml
+++ b/catchpoint/jinja/variables/cloud-init.yaml
@@ -1,2 +1,3 @@
+prom_host: https://prometheus-us-central1.grafana.net
 prom_user: your_prometheus_username
 prom_pass: your_prometheus_password

--- a/catchpoint/prometheus_metrics
+++ b/catchpoint/prometheus_metrics
@@ -1,0 +1,251 @@
+# HELP catchpoint_any_error Indicates if any error occurred during the test.
+# TYPE catchpoint_any_error gauge
+catchpoint_any_error{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_cached_count Number of cached elements accessed during the test.
+# TYPE catchpoint_cached_count gauge
+catchpoint_cached_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_client_time Client processing time in milliseconds.
+# TYPE catchpoint_client_time gauge
+catchpoint_client_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 129
+# HELP catchpoint_connect_time Time taken to connect to the URL in milliseconds.
+# TYPE catchpoint_connect_time gauge
+catchpoint_connect_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 18
+# HELP catchpoint_connection_error Indicates if a connection error occurred during the test.
+# TYPE catchpoint_connection_error gauge
+catchpoint_connection_error{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_connections_count Total number of connections made during the test.
+# TYPE catchpoint_connections_count gauge
+catchpoint_connections_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 13
+# HELP catchpoint_content_load_time Time taken to load content in milliseconds.
+# TYPE catchpoint_content_load_time gauge
+catchpoint_content_load_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 4026
+# HELP catchpoint_css_content_type Size of CSS content loaded during the test in bytes.
+# TYPE catchpoint_css_content_type gauge
+catchpoint_css_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 234787
+# HELP catchpoint_css_count Number of CSS documents loaded during the test.
+# TYPE catchpoint_css_count gauge
+catchpoint_css_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 2
+# HELP catchpoint_dns_error Indicates if a DNS error occurred during the test.
+# TYPE catchpoint_dns_error gauge
+catchpoint_dns_error{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_dns_time Time taken to resolve the domain name in milliseconds.
+# TYPE catchpoint_dns_time gauge
+catchpoint_dns_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 21
+# HELP catchpoint_document_complete_time Time taken for the browser to fully render the page after all resources are downloaded in milliseconds.
+# TYPE catchpoint_document_complete_time gauge
+catchpoint_document_complete_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 237
+# HELP catchpoint_error_objects_loaded Indicates if error objects were loaded during the test.
+# TYPE catchpoint_error_objects_loaded gauge
+catchpoint_error_objects_loaded{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 1
+# HELP catchpoint_failed_requests_count Number of failed requests during the test.
+# TYPE catchpoint_failed_requests_count gauge
+catchpoint_failed_requests_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 4
+# HELP catchpoint_font_content_type Size of font content loaded during the test in bytes.
+# TYPE catchpoint_font_content_type gauge
+catchpoint_font_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 109707
+# HELP catchpoint_font_count Number of font resources loaded during the test.
+# TYPE catchpoint_font_count gauge
+catchpoint_font_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 5
+# HELP catchpoint_hosts_count Total number of hosts contacted during the test.
+# TYPE catchpoint_hosts_count gauge
+catchpoint_hosts_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 24
+# HELP catchpoint_html_content_type Size of HTML content loaded during the test in bytes.
+# TYPE catchpoint_html_content_type gauge
+catchpoint_html_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 114760
+# HELP catchpoint_html_count Number of HTML documents loaded during the test.
+# TYPE catchpoint_html_count gauge
+catchpoint_html_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 3
+# HELP catchpoint_image_content_type Size of image content loaded during the test in bytes.
+# TYPE catchpoint_image_content_type gauge
+catchpoint_image_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 580540
+# HELP catchpoint_image_count Number of image elements loaded during the test.
+# TYPE catchpoint_image_count gauge
+catchpoint_image_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 16
+# HELP catchpoint_load_error Indicates if a load error occurred during the test.
+# TYPE catchpoint_load_error gauge
+catchpoint_load_error{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 1
+# HELP catchpoint_load_time Time taken to load the first and last byte of the primary URL in milliseconds.
+# TYPE catchpoint_load_time gauge
+catchpoint_load_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 587
+# HELP catchpoint_media_content_type Size of media content loaded during the test in bytes.
+# TYPE catchpoint_media_content_type gauge
+catchpoint_media_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_media_count Number of media elements loaded during the test.
+# TYPE catchpoint_media_count gauge
+catchpoint_media_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_other_content_type Size of other content loaded during the test in bytes.
+# TYPE catchpoint_other_content_type gauge
+catchpoint_other_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_redirect_time Time taken for HTTP redirects in milliseconds.
+# TYPE catchpoint_redirect_time gauge
+catchpoint_redirect_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 202
+# HELP catchpoint_redirections_count Number of HTTP redirections encountered during the test.
+# TYPE catchpoint_redirections_count gauge
+catchpoint_redirections_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 2
+# HELP catchpoint_render_start_time Time taken to start rendering the webpage in milliseconds.
+# TYPE catchpoint_render_start_time gauge
+catchpoint_render_start_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 568
+# HELP catchpoint_requests_count Number of requests made during the test.
+# TYPE catchpoint_requests_count gauge
+catchpoint_requests_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 50
+# HELP catchpoint_response_content_size Size of the HTTP response content in bytes.
+# TYPE catchpoint_response_content_size gauge
+catchpoint_response_content_size{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 88884
+# HELP catchpoint_response_headers_size Size of the HTTP response headers in bytes.
+# TYPE catchpoint_response_headers_size gauge
+catchpoint_response_headers_size{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 2197
+# HELP catchpoint_script_content_type Size of script content loaded during the test in bytes.
+# TYPE catchpoint_script_content_type gauge
+catchpoint_script_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 534736
+# HELP catchpoint_script_count Number of script elements loaded during the test.
+# TYPE catchpoint_script_count gauge
+catchpoint_script_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 22
+# HELP catchpoint_ssl_time Time taken to establish SSL handshake in milliseconds.
+# TYPE catchpoint_ssl_time gauge
+catchpoint_ssl_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 16
+# HELP catchpoint_timeout_error Indicates if a timeout error occurred during the test.
+# TYPE catchpoint_timeout_error gauge
+catchpoint_timeout_error{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_total_content_size Total size of the HTTP response content and headers in bytes.
+# TYPE catchpoint_total_content_size gauge
+catchpoint_total_content_size{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 1.974769e+06
+# HELP catchpoint_total_headers_size Total size of the HTTP response headers in bytes.
+# TYPE catchpoint_total_headers_size gauge
+catchpoint_total_headers_size{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 58142
+# HELP catchpoint_total_time Total time it took to load the webpage in milliseconds.
+# TYPE catchpoint_total_time gauge
+catchpoint_total_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 1731
+# HELP catchpoint_tracepoints_count Number of tracepoints hit during the test.
+# TYPE catchpoint_tracepoints_count gauge
+catchpoint_tracepoints_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_transaction_error Indicates if a transaction error occurred during the test.
+# TYPE catchpoint_transaction_error gauge
+catchpoint_transaction_error{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 1
+# HELP catchpoint_up Catchpoint exporter is up and running.
+# TYPE catchpoint_up gauge
+catchpoint_up 1
+# HELP catchpoint_wait_time Time from successful connection to receiving the first byte in milliseconds.
+# TYPE catchpoint_wait_time gauge
+catchpoint_wait_time{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 552
+# HELP catchpoint_xml_content_type Size of XML content loaded during the test in bytes.
+# TYPE catchpoint_xml_content_type gauge
+catchpoint_xml_content_type{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP catchpoint_xml_count Number of XML documents loaded during the test.
+# TYPE catchpoint_xml_count gauge
+catchpoint_xml_count{asn="46678",client_id="832",division_id="2342",monitor_type_id="18",node_name="Chicago, US - AT&T",test_id="8104714",test_name="Homepage fast",type_id="0"} 0
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.000105418
+go_gc_duration_seconds{quantile="0.25"} 0.000559549
+go_gc_duration_seconds{quantile="0.5"} 0.001569319
+go_gc_duration_seconds{quantile="0.75"} 0.001852841
+go_gc_duration_seconds{quantile="1"} 0.002233992
+go_gc_duration_seconds_sum 0.008854162
+go_gc_duration_seconds_count 7
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 10
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.22.2"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 2.142832e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 7.725304e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 8139
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 15384
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 2.571496e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 2.142832e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 4.186112e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 3.547136e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 2855
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 3.432448e+06
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 7.733248e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.7164289184480557e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 18239
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 4800
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 15600
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 80960
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 97920
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 4.194304e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 967661
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 622592
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 622592
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.2016656e+07
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 7
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.27
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 10
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.406976e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.71642789193e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.264275456e+09
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes 1.8446744073709552e+19
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight 1
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{code="200"} 17
+promhttp_metric_handler_requests_total{code="500"} 0
+promhttp_metric_handler_requests_total{code="503"} 0

--- a/catchpoint/scripts/Dockerfile
+++ b/catchpoint/scripts/Dockerfile
@@ -1,14 +1,18 @@
-# Use a Go image as the base image
 FROM --platform=linux/arm64 golang:latest as builder
 
-
 WORKDIR /app
-RUN git clone https://github.com/JonathanWamsley/catchpoint-prometheus-exporter.git .
+
+
+RUN apt-get update && apt-get install -y git curl jq
+RUN git clone https://github.com/grafana/catchpoint-prometheus-exporter.git .
+RUN git fetch origin +refs/pull/*/head:refs/remotes/origin/pr/*
+# undo the requirement for a PR number after pr is merged
+RUN PR_NUM=$(curl -s https://api.github.com/repos/grafana/catchpoint-prometheus-exporter/pulls | jq -r '.[0].number') \
+    && git checkout origin/pr/$PR_NUM
 
 # Set environment variable to build a static binary
 ENV CGO_ENABLED=0
 ENV GOOS=linux
-# ENV GOARCH=amd64
 ENV GOARCH=arm64
 
 # Download all dependencies
@@ -16,16 +20,12 @@ RUN go mod tidy
 
 # Build the application as a static binary
 RUN go build -ldflags '-extldflags "-static"' -o catchpoint-exporter ./cmd/catchpoint-exporter/main.go
-
-# Use a minimal base image from scratch
-# FROM scratch
 FROM --platform=linux/arm64 alpine:latest as final
 WORKDIR /root/
 
-# Install basic tools
-RUN apk add --no-cache bash
-
 COPY --from=builder /app/catchpoint-exporter .
-EXPOSE 8080
+EXPOSE 9090
+
+# Configure the container to run as an executable
 ENTRYPOINT ["./catchpoint-exporter"]
-CMD ["--bearer-token=yourtoken", "--node-ids=1,2"]
+CMD ["--port=9090", "--webhook-path=/webhook", "--verbose"]

--- a/catchpoint/scripts/Dockerfile
+++ b/catchpoint/scripts/Dockerfile
@@ -1,0 +1,31 @@
+# Use a Go image as the base image
+FROM --platform=linux/arm64 golang:latest as builder
+
+
+WORKDIR /app
+RUN git clone https://github.com/JonathanWamsley/catchpoint-prometheus-exporter.git .
+
+# Set environment variable to build a static binary
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+# ENV GOARCH=amd64
+ENV GOARCH=arm64
+
+# Download all dependencies
+RUN go mod tidy
+
+# Build the application as a static binary
+RUN go build -ldflags '-extldflags "-static"' -o catchpoint-exporter ./cmd/catchpoint-exporter/main.go
+
+# Use a minimal base image from scratch
+# FROM scratch
+FROM --platform=linux/arm64 alpine:latest as final
+WORKDIR /root/
+
+# Install basic tools
+RUN apk add --no-cache bash
+
+COPY --from=builder /app/catchpoint-exporter .
+EXPOSE 8080
+ENTRYPOINT ["./catchpoint-exporter"]
+CMD ["--bearer-token=yourtoken", "--node-ids=1,2"]

--- a/catchpoint/scripts/Dockerfile
+++ b/catchpoint/scripts/Dockerfile
@@ -6,9 +6,6 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y git curl jq
 RUN git clone https://github.com/grafana/catchpoint-prometheus-exporter.git .
 RUN git fetch origin +refs/pull/*/head:refs/remotes/origin/pr/*
-# undo the requirement for a PR number after pr is merged
-RUN PR_NUM=$(curl -s https://api.github.com/repos/grafana/catchpoint-prometheus-exporter/pulls | jq -r '.[0].number') \
-    && git checkout origin/pr/$PR_NUM
 
 # Set environment variable to build a static binary
 ENV CGO_ENABLED=0

--- a/catchpoint/scripts/init_script.sh
+++ b/catchpoint/scripts/init_script.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+sudo snap install kubectl --classic
+
+# Determine the architecture
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+    MINIKUBE_BIN="minikube-linux-amd64"
+else
+    MINIKUBE_BIN="minikube-linux-arm64"
+fi
+
+# Setup Minikube
+curl -LO "https://storage.googleapis.com/minikube/releases/latest/$MINIKUBE_BIN"
+sudo install $MINIKUBE_BIN /usr/local/bin/minikube
+minikube start --memory=12000 --cpus=4 --kubernetes-version=v1.23.17 # Version for Docker support
+GATEWAY_IP="$(ip r | grep default | cut -d' ' -f3)"
+echo "$GATEWAY_IP catchpoint.k3d.localhost" | sudo tee -a /etc/hosts
+
+sudo snap install helm --classic
+
+# Apply Kubernetes resources for Catchpoint Exporter from the generated_configs directory
+kubectl apply -f /catchpoint/config/catchpoint-exporter-deployment.yaml
+kubectl apply -f /catchpoint/config/catchpoint-exporter-service.yaml
+
+# Install Grafana Agent Flow
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+helm install grafana-agent-flow grafana/k8s-monitoring -n default --values /catchpoint/config/grafana-flow-k8s-template.yaml

--- a/catchpoint/scripts/post_metrics.py
+++ b/catchpoint/scripts/post_metrics.py
@@ -1,0 +1,107 @@
+import requests
+import time
+import random
+
+# Define the node names and test names
+node_names = [
+    "Bangalore, IN - Tata Teleservices", 
+    "Los Angeles, US - Comcast", 
+    "Chicago, US - AT&T", 
+    "New York, US - Cogent", 
+    "Miami, US - AT&T"
+]
+
+test_names = ["Homepage fast", "Homepage med", "Homepage slow", "Homepage variance"]
+
+# URL for the webhook endpoint
+webhook_url = "http://localhost:9090/webhook"
+
+def generate_metrics(test_name):
+    base_time = {
+        "Homepage fast": random.randint(1000, 2000),
+        "Homepage med": random.randint(2000, 4000),
+        "Homepage slow": random.randint(4000, 6000),
+        "Homepage variance": random.randint(500, 7000)
+    }
+
+    total_time = base_time[test_name]
+
+    return {
+        "TestDetails": {
+            "TestName": test_name,
+            "TypeId": "0",
+            "MonitorTypeId": "18",
+            "TestId": str(random.randint(1000000, 9999999)),
+            "ReportWindow": str(random.randint(1000000000000000, 9999999999999999)),
+            "NodeId": str(random.randint(1000, 2000)),
+            "NodeName": random.choice(node_names),
+            "Asn": str(random.randint(40000, 60000)),
+            "DivisionId": str(random.randint(2000, 3000)),
+            "ClientId": str(random.randint(800, 900))
+        },
+        "Summary": {
+            "Timestamp": str(int(time.time() * 1000)),
+            "TotalTime": str(total_time),
+            "Connect": str(random.randint(10, 30)),
+            "Dns": str(random.randint(20, 50)),
+            "ContentLoad": str(random.randint(500, 8000)),
+            "Load": str(random.randint(500, 1000)),
+            "Redirect": str(random.randint(200, 500)),
+            "Send": "0",
+            "SSL": str(random.randint(10, 30)),
+            "Wait": str(random.randint(500, 1000)),
+            "Client": str(random.randint(100, 200)),
+            "DocumentComplete": str(total_time - random.randint(0, total_time)),
+            "Dom Loaded": "",
+            "Time To Title": "",
+            "RenderStart": str(total_time - random.randint(0, total_time)),
+            "ResponseContent": str(random.randint(50000, 200000)),
+            "ResponseHeaders": str(random.randint(2000, 3000)),
+            "TotalContent": str(random.randint(1000000, 2000000)),
+            "TotalHeaders": str(random.randint(50000, 60000)),
+            "AnyError": "False",
+            # Set to False 80% of the time, else True
+            "ConnectionError": "False" if random.randint(0, 1) < 0.8 else "True",
+            "DNSError": "False" if random.randint(0, 1) < 0.8 else "True",
+            "LoadError": "False" if random.randint(0, 1) < 0.8 else "True",
+            "TimeoutError": "False" if random.randint(0, 1) < 0.8 else "True",
+            "TransactionError": "False" if random.randint(0, 1) < 0.8 else "True",
+            "ErrorObjectsLoaded": "False" if random.randint(0, 1) < 0.8 else "True",
+            "ImageContentType": str(random.randint(500000, 600000)),
+            "ScriptContentType": str(random.randint(500000, 600000)),
+            "HTMLContentType": str(random.randint(100000, 200000)),
+            "CSSContentType": str(random.randint(200000, 300000)),
+            "FontContentType": str(random.randint(100000, 200000)),
+            "MediaContentType": "0",
+            "XMLContentType": "0",
+            "OtherContentType": "0",
+            "ConnectionsCount": str(random.randint(10, 20)),
+            "HostsCount": str(random.randint(20, 30)),
+            "FailedRequestsCount": str(random.randint(1, 6)),
+            "RequestsCount": str(random.randint(50, 70)),
+            "RedirectionsCount": str(random.randint(0, 5)),
+            "CachedCount": "0",
+            "ImageCount": str(random.randint(10, 20)),
+            "ScriptCount": str(random.randint(10, 30)),
+            "HTMLCount": str(random.randint(1, 5)),
+            "CSSCount": str(random.randint(1, 5)),
+            "FontCount": str(random.randint(1, 5)),
+            "XMLCount": "0",
+            "MediaCount": "0",
+            "ReceiveCount": "",
+            "SendCount": "",
+            "TracepointsCount": "0"
+        }
+    }
+
+def main():
+    while True:
+        for test_name in test_names:
+            payload = generate_metrics(test_name)
+            response = requests.post(webhook_url, json=payload)
+            print(f"Sent {test_name} metrics, Response Code: {response.status_code}")
+            time.sleep(50)  # Sleep for 30 seconds between requests
+        time.sleep(50)  # Sleep for 30 seconds between requests
+
+if __name__ == "__main__":
+    main()

--- a/catchpoint/scripts/post_metrics.py
+++ b/catchpoint/scripts/post_metrics.py
@@ -16,15 +16,27 @@ test_names = ["Homepage fast", "Homepage med", "Homepage slow", "Homepage varian
 # URL for the webhook endpoint
 webhook_url = "http://localhost:9090/webhook"
 
+# Define region modifiers
+region_modifiers = {
+    "Bangalore, IN - Tata Teleservices": 1.5,
+    "Los Angeles, US - Comcast": 1.2,
+    "Chicago, US - AT&T": 1.0,
+    "New York, US - Cogent": 0.8,
+    "Miami, US - AT&T": 0.9
+}
+
 def generate_metrics(test_name):
     base_time = {
-        "Homepage fast": random.randint(1000, 2000),
-        "Homepage med": random.randint(2000, 4000),
-        "Homepage slow": random.randint(4000, 6000),
-        "Homepage variance": random.randint(500, 7000)
+        "Homepage fast": random.randint(500, 1000),
+        "Homepage med": random.randint(2000, 3000),
+        "Homepage slow": random.randint(5000, 7000),
+        "Homepage variance": random.randint(500, 8000)
     }
 
     total_time = base_time[test_name]
+    node_name = random.choice(node_names)
+    region_modifier = region_modifiers[node_name]
+    total_time = int(total_time * region_modifier)
 
     return {
         "TestDetails": {
@@ -34,7 +46,7 @@ def generate_metrics(test_name):
             "TestId": str(random.randint(1000000, 9999999)),
             "ReportWindow": str(random.randint(1000000000000000, 9999999999999999)),
             "NodeId": str(random.randint(1000, 2000)),
-            "NodeName": random.choice(node_names),
+            "NodeName": node_name,
             "Asn": str(random.randint(40000, 60000)),
             "DivisionId": str(random.randint(2000, 3000)),
             "ClientId": str(random.randint(800, 900))
@@ -42,31 +54,27 @@ def generate_metrics(test_name):
         "Summary": {
             "Timestamp": str(int(time.time() * 1000)),
             "TotalTime": str(total_time),
-            "Connect": str(random.randint(10, 30)),
-            "Dns": str(random.randint(20, 50)),
-            "ContentLoad": str(random.randint(500, 8000)),
-            "Load": str(random.randint(500, 1000)),
-            "Redirect": str(random.randint(200, 500)),
-            "Send": "0",
-            "SSL": str(random.randint(10, 30)),
-            "Wait": str(random.randint(500, 1000)),
-            "Client": str(random.randint(100, 200)),
+            "Connect": str(int(random.randint(10, 30) * region_modifier)),
+            "Dns": str(int(random.randint(20, 50) * region_modifier)),
+            "ContentLoad": str(int(random.randint(500, 8000) * region_modifier)),
+            "Load": str(int(random.randint(500, 1000) * region_modifier)),
+            "Redirect": str(int(random.randint(200, 500) * region_modifier)),
+            "SSL": str(int(random.randint(10, 30) * region_modifier)),
+            "Wait": str(int(random.randint(500, 1000) * region_modifier)),
+            "Client": str(int(random.randint(100, 200) * region_modifier)),
             "DocumentComplete": str(total_time - random.randint(0, total_time)),
-            "Dom Loaded": "",
-            "Time To Title": "",
             "RenderStart": str(total_time - random.randint(0, total_time)),
             "ResponseContent": str(random.randint(50000, 200000)),
             "ResponseHeaders": str(random.randint(2000, 3000)),
             "TotalContent": str(random.randint(1000000, 2000000)),
             "TotalHeaders": str(random.randint(50000, 60000)),
-            "AnyError": "False",
-            # Set to False 80% of the time, else True
-            "ConnectionError": "False" if random.randint(0, 1) < 0.8 else "True",
-            "DNSError": "False" if random.randint(0, 1) < 0.8 else "True",
-            "LoadError": "False" if random.randint(0, 1) < 0.8 else "True",
-            "TimeoutError": "False" if random.randint(0, 1) < 0.8 else "True",
-            "TransactionError": "False" if random.randint(0, 1) < 0.8 else "True",
-            "ErrorObjectsLoaded": "False" if random.randint(0, 1) < 0.8 else "True",
+            "AnyError": "False" if random.random() < 0.8 else "True", # Set to False 80% of the time, else True
+            "ConnectionError": "False" if random.random() < 0.8 else "True",
+            "DNSError": "False" if random.random() < 0.8 else "True",
+            "LoadError": "False" if random.random() < 0.8 else "True",
+            "TimeoutError": "False" if random.random() < 0.8 else "True",
+            "TransactionError": "False" if random.random() < 0.8 else "True",
+            "ErrorObjectsLoaded": "False" if random.random() < 0.8 else "True",
             "ImageContentType": str(random.randint(500000, 600000)),
             "ScriptContentType": str(random.randint(500000, 600000)),
             "HTMLContentType": str(random.randint(100000, 200000)),
@@ -80,7 +88,7 @@ def generate_metrics(test_name):
             "FailedRequestsCount": str(random.randint(1, 6)),
             "RequestsCount": str(random.randint(50, 70)),
             "RedirectionsCount": str(random.randint(0, 5)),
-            "CachedCount": "0",
+            "CachedCount": str(random.randint(0, 10)),
             "ImageCount": str(random.randint(10, 20)),
             "ScriptCount": str(random.randint(10, 30)),
             "HTMLCount": str(random.randint(1, 5)),
@@ -88,8 +96,6 @@ def generate_metrics(test_name):
             "FontCount": str(random.randint(1, 5)),
             "XMLCount": "0",
             "MediaCount": "0",
-            "ReceiveCount": "",
-            "SendCount": "",
             "TracepointsCount": "0"
         }
     }
@@ -100,8 +106,7 @@ def main():
             payload = generate_metrics(test_name)
             response = requests.post(webhook_url, json=payload)
             print(f"Sent {test_name} metrics, Response Code: {response.status_code}")
-            time.sleep(50)  # Sleep for 30 seconds between requests
-        time.sleep(50)  # Sleep for 30 seconds between requests
+            time.sleep(50)  # Sleep for 50 seconds between individual requests
 
 if __name__ == "__main__":
     main()

--- a/catchpoint/scripts/render_template.py
+++ b/catchpoint/scripts/render_template.py
@@ -1,0 +1,35 @@
+# /scripts/render_template.py
+import yaml
+import jinja2
+import os
+
+def render_templates(config_file, template_dir, output_dir):
+    # Load configuration
+    with open(config_file) as file:
+        config = yaml.safe_load(file)
+
+    # Set up Jinja2 environment
+    template_loader = jinja2.FileSystemLoader(searchpath=template_dir)
+    template_env = jinja2.Environment(loader=template_loader)
+    
+    # Render templates
+    for template_file in template_env.list_templates():
+        template = template_env.get_template(template_file)
+        output = template.render(config)
+
+        # Write output to file
+        output_file_path = os.path.join(output_dir, template_file.replace('.j2', ''))
+        with open(output_file_path, "w") as f:
+            f.write(output)
+        print(f"Generated: {output_file_path}")
+
+# Define file paths
+config_file = "jinja/variables/cloud-init.yaml"
+template_dir = "jinja/templates"
+output_dir = "generated_configs"  # Output directory for rendered files
+
+# Create output directory if it doesn't exist
+os.makedirs(output_dir, exist_ok=True)
+
+# Run the rendering process
+render_templates(config_file, template_dir, output_dir)

--- a/catchpoint/scripts/render_template.py
+++ b/catchpoint/scripts/render_template.py
@@ -33,3 +33,4 @@ os.makedirs(output_dir, exist_ok=True)
 
 # Run the rendering process
 render_templates(config_file, template_dir, output_dir)
+

--- a/catchpoint/scripts/setup_docker.sh
+++ b/catchpoint/scripts/setup_docker.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+sudo apt-get update
+sudo apt-get install ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+. /etc/os-release && export CODENAME=$VERSION_CODENAME && export ARCH=$(dpkg --print-architecture) && echo \
+    "deb [arch=$(echo $ARCH) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(echo $CODENAME) stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo groupadd docker
+sudo usermod -aG docker $USER


### PR DESCRIPTION
Adds an easy way to create a multipass instance running kubernetes with the prometheus exporter setup to send mock metrics using Grafana flow to Grafana Cloud testing multiple test names and node names.