### PR TITLE
Replace tj-actions/changed-files with step-security/changed-files

### DIFF
--- a/.github/workflows/integration-sample-app-qa.yml
+++ b/.github/workflows/integration-sample-app-qa.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get changed sample apps
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           path: sample-apps
           dir_names: true


### PR DESCRIPTION
This PR replaces the recently compromised action `tj-actions/changed-files` with `step-security/changed-files`, and introduces version pinning