### PR TITLE
Add missing conditional for VM_K3S_NAME in makefile

### DIFF
--- a/sample-apps/Makefile
+++ b/sample-apps/Makefile
@@ -10,6 +10,8 @@ OPS_SCRIPTS_DIR = "../../ops/scripts"
 VM_MAIN = ""
 ifdef VM_CLUSTER_MAIN
 	VM_MAIN = $(VM_CLUSTER_MAIN)
+else ifdev VM_K3S_NAME
+	VM_MAIN = $(VM_K3S_NAME)
 else
 	VM_MAIN = $(VM_NAME)
 endif


### PR DESCRIPTION
This PR introduces the missing conditional for `VM_K3S_NAME` in the shared sample-app makefile, allowing certainty in selecting the main VM of a given sample-app