### PR TITLE
chore: Pin varnish docker builder stage image to bookworm

### DIFF
--- a/sample-apps/varnish-cache/configs/Dockerfile
+++ b/sample-apps/varnish-cache/configs/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS stage
+FROM debian:bookworm-slim AS stage
 
 WORKDIR /exporter
 ADD https://github.com/jonnenauha/prometheus_varnish_exporter/releases/download/1.6.1/prometheus_varnish_exporter-1.6.1.linux-amd64.tar.gz /exporter/exporter.tar.gz


### PR DESCRIPTION
```
Step 6/9 : RUN dpkg --add-architecture amd64  && apt-get update && apt-get install -y libc6-dev
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in dd4496e4d30b
Get:1 http://deb.debian.org/debian stable InRelease [140 kB]
Get:2 http://deb.debian.org/debian stable-updates InRelease [47.3 kB]
Err:1 http://deb.debian.org/debian stable InRelease
  No good signature
Err:2 http://deb.debian.org/debian stable-updates InRelease
  No good signature
Get:3 http://deb.debian.org/debian-security stable-security InRelease [43.4 kB]
Err:3 http://deb.debian.org/debian-security stable-security InRelease
  No good signature
Reading package lists...
W: OpenPGP signature verification failed: http://deb.debian.org/debian stable InRelease: No good signature
E: The repository 'http://deb.debian.org/debian stable InRelease' is not signed.
W: OpenPGP signature verification failed: http://deb.debian.org/debian stable-updates InRelease: No good signature
E: The repository 'http://deb.debian.org/debian stable-updates InRelease' is not signed.
W: OpenPGP signature verification failed: http://deb.debian.org/debian-security stable-security InRelease: No good signature
E: The repository 'http://deb.debian.org/debian-security stable-security InRelease' is not signed.
The command '/bin/sh -c dpkg --add-architecture amd64  && apt-get update && apt-get install -y libc6-dev' returned a non-zero code: 100
```

Was running into this error due to the builder stage targeting `trixie` and the call to apt-get update was failing. Decided to pin to bookworm and everything should be working. 