### PR TITLE
Improve varnish config for better default data

### DIFF
--- a/sample-apps/varnish-cache/configs/templates/configmaps.yaml
+++ b/sample-apps/varnish-cache/configs/templates/configmaps.yaml
@@ -64,8 +64,13 @@ data:
     }
 
     sub vcl_recv {
-        # Force a cache miss to ensure backend requests
-        return (pass);
+        if (req.method != "GET" && req.method != "HEAD") {
+            return (pass);
+        }
+        if (req.url ~ "\?.*") {
+            set req.url = regsub(req.url, "\?.*", "");
+        }
+        return (hash);
     }
 
     sub vcl_backend_response {
@@ -75,7 +80,10 @@ data:
     sub vcl_deliver {
         if (obj.hits > 0) {
             set resp.http.X-Cache = "HIT";
+            set resp.http.X-Cache-Hits = obj.hits;
         } else {
             set resp.http.X-Cache = "MISS";
         }
+        set resp.http.X-Age = obj.age;
+        unset resp.http.X-Cache-TTL;
     }

--- a/sample-apps/varnish-cache/configs/templates/cronjob.yaml
+++ b/sample-apps/varnish-cache/configs/templates/cronjob.yaml
@@ -39,10 +39,9 @@ spec:
               echo "Request failed with exit code $?"
               
               # Make a few more requests to generate some load
-              for i in $(seq 1 5); do
+              for i in $(seq 1 1000); do
                 curl -f -s -o /dev/null http://varnish-cache.varnish.svc.cluster.local:80/ && \
                 echo "Request $i: Success" || echo "Request $i: Failed"
-                sleep 1
               done
           activeDeadlineSeconds: 60
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
This changes the Varnish config to do more caching of our loadgen and generate more interesting graphs with the data that the prometheus exporter is emitting. Also bumped the number of requests we're making to the cache so its relatively more busy on the dashboard.

Before:
<img width="2560" height="1198" alt="image" src="https://github.com/user-attachments/assets/802b7481-d5bd-4ad8-b512-ef92216e47b2" />


After:
<img width="2559" height="1220" alt="image" src="https://github.com/user-attachments/assets/9f03e61a-5244-4597-8009-1e3f4765a906" />
