### PR TITLE
fix: set mesos_cluster for apache mesos sample app

### DIFF
--- a/sample-apps/apache-mesos/configs/suo.alloy
+++ b/sample-apps/apache-mesos/configs/suo.alloy
@@ -26,6 +26,11 @@ discovery.relabel "apache_mesos" {
 		replacement  = "integrations/apache-mesos"
 		target_label = "job"
 	}
+
+    rule {
+        replacement = "apache-mesos-sample-app-cluster"
+        target_label = "mesos_cluster"
+    }
 }
 
 discovery.relabel "apache_mesos_agent" {


### PR DESCRIPTION
A lot of the mesos mixin legends appear to be most usable with this set. Apologies for the miss!