### PR TITLE
update mssql sample app to account for go upgrade

### DIFF
--- a/sample-apps/mssql/jinja/templates/cloud-init-template.yaml
+++ b/sample-apps/mssql/jinja/templates/cloud-init-template.yaml
@@ -185,7 +185,7 @@ runcmd:
   # Wait for SQL Server to be ready and set up monitoring user
   - |
     # Wait for SQL Server to be ready (up to 60 seconds)
-    for i in {1..60}; do
+    for i in {1..120}; do
       if docker run --rm --platform linux/amd64 --network host mcr.microsoft.com/mssql-tools /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P reallyStrongPwd123 -Q "SELECT 1" &> /dev/null; then
         break
       fi

--- a/sample-apps/mssql/jinja/templates/cloud-init-template.yaml
+++ b/sample-apps/mssql/jinja/templates/cloud-init-template.yaml
@@ -70,7 +70,7 @@ write_files:
       }
      
       prometheus.exporter.mssql "integrations_mssql" {
-        connection_string = "sqlserver://SA:reallyStrongPwd123@localhost:1433?TrustServerCertificate=true"
+        connection_string = "sqlserver://SA:reallyStrongPwd123@localhost:1433?TrustServerCertificate=true&encrypt=disable"
       }
 
       discovery.relabel "integrations_mssql" {


### PR DESCRIPTION
In a recent version of Golang for Alloy 

> [ParsePKCS1PrivateKey](https://go.dev/pkg/crypto/x509#ParsePKCS1PrivateKey) and [ParsePKCS8PrivateKey](https://go.dev/pkg/crypto/x509#ParsePKCS8PrivateKey) now use and validate the encoded CRT values, so might reject invalid RSA keys that were previously accepted. Use [GODEBUG setting](https://go.dev/doc/godebug) x509rsacrt=0 to revert to recomputing the CRT values.


https://go.dev/doc/go1.24

I believe that we were rejecting this in the alloy connection string and the call to the Parse was yielding these errors:

> failed to parse certificate from server: x509: negative serial number"

So this changes the sql server configuration to not validate the cert.