### PR TITLE
Skip/disable minimum Release Age checks for incompatible types & sources

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,21 @@
       ],
       "additionalBranchPrefix": "{{#if isGroup }}{{ else }}{{packageFileDir}}/{{/if}}",
       "commitMessageSuffix": "{{#if isGroup }}{{ else }} ({{packageFileDir}}){{/if}}"
+    },
+    { 
+      "description": "Disable minimum release age check for update types that don't support timestamps",
+      "matchUpdateTypes": ["pin", "pinDigest", "digest"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Disable minimum release age for specific images in container registries that don't provide release timestamps (ghcr.io, quay.io).",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/observiq/varnish-exporter",
+        "ghcr.io/oracle/oraclelinux9-instantclient",
+        "quay.io/prometheus/statsd-exporter"
+      ],
+      "minimumReleaseAge": null
     }
   ]
 }


### PR DESCRIPTION
What the title says. Some of our renovate updates get blocked hard by the minimum release age check and can't be bypassed on the PR without this.

Source: https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-datasources-support-release-timestamps