### PR TITLE
Add MongoDB log collection and sharded-cluster support 

### DIFF
--- a/sample-apps/mongodb/Makefile
+++ b/sample-apps/mongodb/Makefile
@@ -3,23 +3,25 @@ CONFIG_FILE_DIR := jinja/variables
 CONFIG_FILE := $(CONFIG_FILE_DIR)/cloud-init.yaml
 LOKI_INSTANCE ?= your-loki-instance:3100
 PROMETHEUS_INSTANCE ?= your-prometheus-instance:9090
-# Cloud-init template and VM size; overridden by run-cluster for the sharded topology
-TEMPLATE ?= cloud-init-template.yaml
-MEMORY ?= 2G
+# Cloud-init template and VM size; default to the sharded cluster topology.
+# Overridden by run-single for the lighter single-replicaset setup.
+TEMPLATE ?= cloud-init-template_local_setup.yaml
+MEMORY ?= 4G
 
 # Import last to ensure expected parameters are set and available to import from this file
 include ../Makefile
 
-.PHONY: run run-cluster run-ci stop exporter fetch-prometheus-metrics render-config launch-vm clean defaultconfig
+.PHONY: run run-single run-ci stop fetch-prometheus-metrics render-config launch-vm clean defaultconfig
 
+# Launch the sharded cluster (config server + two shards + mongos)
 run: launch-vm
-	@echo "VM $(VM_NAME) launched and configured."
-
-# Launch the sharded cluster (config server + two shards + mongos) instead of the single replicaset
-run-cluster: TEMPLATE = cloud-init-template_local_setup.yaml
-run-cluster: MEMORY = 4G
-run-cluster: launch-vm
 	@echo "VM $(VM_NAME) launched with sharded cluster."
+
+# Launch the lighter single replicaset instead of the sharded cluster
+run-single: TEMPLATE = cloud-init-template.yaml
+run-single: MEMORY = 2G
+run-single: launch-vm
+	@echo "VM $(VM_NAME) launched with single replicaset."
 
 run-ci: clean defaultconfig launch-vm
 	@echo "Running in CI mode"
@@ -33,7 +35,7 @@ fetch-prometheus-metrics:
 	@multipass exec $(VM_NAME) -- curl http://localhost:9127/metrics > prometheus_metrics
 
 render-config:
-	@docker run --rm -v $(shell pwd)/jinja/templates:/templates -v $(shell pwd)/jinja/variables:/variables dinutac/jinja2docker:latest /templates/$(TEMPLATE) /variables/cloud-init.yaml --format=yaml > cloud-init.yaml
+	@docker run --rm -v $(shell pwd)/jinja/templates:/templates -v $(shell pwd)/$(CONFIG_FILE_DIR):/variables dinutac/jinja2docker:latest /templates/$(TEMPLATE) /variables/$(notdir $(CONFIG_FILE)) --format=yaml > cloud-init.yaml
 
 launch-vm: render-config
 	@multipass launch 24.04 -n $(VM_NAME) --cpus 4 --memory $(MEMORY) --disk 15G --cloud-init cloud-init.yaml

--- a/sample-apps/mongodb/Makefile
+++ b/sample-apps/mongodb/Makefile
@@ -3,14 +3,23 @@ CONFIG_FILE_DIR := jinja/variables
 CONFIG_FILE := $(CONFIG_FILE_DIR)/cloud-init.yaml
 LOKI_INSTANCE ?= your-loki-instance:3100
 PROMETHEUS_INSTANCE ?= your-prometheus-instance:9090
+# Cloud-init template and VM size; overridden by run-cluster for the sharded topology
+TEMPLATE ?= cloud-init-template.yaml
+MEMORY ?= 2G
 
 # Import last to ensure expected parameters are set and available to import from this file
 include ../Makefile
 
-.PHONY: run run-ci stop exporter fetch-prometheus-metrics render-config launch-vm clean defaultconfig
+.PHONY: run run-cluster run-ci stop exporter fetch-prometheus-metrics render-config launch-vm clean defaultconfig
 
 run: launch-vm
 	@echo "VM $(VM_NAME) launched and configured."
+
+# Launch the sharded cluster (config server + two shards + mongos) instead of the single replicaset
+run-cluster: TEMPLATE = cloud-init-template_local_setup.yaml
+run-cluster: MEMORY = 4G
+run-cluster: launch-vm
+	@echo "VM $(VM_NAME) launched with sharded cluster."
 
 run-ci: clean defaultconfig launch-vm
 	@echo "Running in CI mode"
@@ -24,10 +33,10 @@ fetch-prometheus-metrics:
 	@multipass exec $(VM_NAME) -- curl http://localhost:9127/metrics > prometheus_metrics
 
 render-config:
-	@docker run --rm -v $(shell pwd)/jinja/templates:/templates -v $(shell pwd)/jinja/variables:/variables dinutac/jinja2docker:latest /templates/cloud-init-template.yaml /variables/cloud-init.yaml --format=yaml > cloud-init.yaml
+	@docker run --rm -v $(shell pwd)/jinja/templates:/templates -v $(shell pwd)/jinja/variables:/variables dinutac/jinja2docker:latest /templates/$(TEMPLATE) /variables/cloud-init.yaml --format=yaml > cloud-init.yaml
 
 launch-vm: render-config
-	@multipass launch 24.04 -n $(VM_NAME) --cpus 4 --memory 2G --disk 15G --cloud-init cloud-init.yaml
+	@multipass launch 24.04 -n $(VM_NAME) --cpus 4 --memory $(MEMORY) --disk 15G --cloud-init cloud-init.yaml
 
 clean:
 	@rm -f cloud-init.yaml

--- a/sample-apps/mongodb/README.md
+++ b/sample-apps/mongodb/README.md
@@ -17,7 +17,7 @@ To get started with the sample app, follow these steps:
 1. **Clone the repository**: 
    ```sh
    git clone https://github.com/grafana/integration-sample-apps.git
-   cd integration-sample-apps/mongodb
+   cd integration-sample-apps/sample-apps/mongodb
    ```
 
 2. **Set up default config**: 
@@ -29,14 +29,15 @@ To get started with the sample app, follow these steps:
 4. **Create and set up VMs**: 
    Use `make run` to start the MongoDB sample app.
 
-6. **Stop and clean Up**: 
+5. **Stop and clean Up**: 
    Use `make stop` to clean up the VM and `make clean` to remove temporary files.
 
 ## Make commands
 
 - `make defaultconfig`: Initializes the configuration file with default values for cloud-init templates.
 - `make render-config`: Generates the `cloud-init.yaml` configuration file using the defined variables.
-- `make run`: Creates the MongoDB sample app, spawning a local three-member replicaset
+- `make run`: Creates the MongoDB sample app, spawning a local three-member replicaset.
+- `make run-cluster`: Creates a sharded cluster instead (config server + two 3-member shards + mongos) for testing cluster dashboards.
 - `make clean`: Deletes all created VMs and performs cleanup.
 
 ## Default configuration variables

--- a/sample-apps/mongodb/README.md
+++ b/sample-apps/mongodb/README.md
@@ -36,8 +36,8 @@ To get started with the sample app, follow these steps:
 
 - `make defaultconfig`: Initializes the configuration file with default values for cloud-init templates.
 - `make render-config`: Generates the `cloud-init.yaml` configuration file using the defined variables.
-- `make run`: Creates the MongoDB sample app, spawning a local three-member replicaset.
-- `make run-cluster`: Creates a sharded cluster instead (config server + two 3-member shards + mongos) for testing cluster dashboards.
+- `make run`: Creates the MongoDB sample app as a sharded cluster (config server + two 3-member shards + mongos) for testing cluster dashboards.
+- `make run-single`: Creates the lighter single three-member replicaset instead.
 - `make clean`: Deletes all created VMs and performs cleanup.
 
 ## Default configuration variables

--- a/sample-apps/mongodb/jinja/templates/cloud-init-template.yaml
+++ b/sample-apps/mongodb/jinja/templates/cloud-init-template.yaml
@@ -41,7 +41,12 @@ runcmd:
   
 
   # Spawn a three node replicaset with a config server and mongos
-  - sudo mlaunch --replicaset 
+  - sudo mlaunch --replicaset --dir /data/mongodb
+
+  # Let the alloy user read the mongod logs created by mlaunch (adm is the conventional log-reader group)
+  - sudo chgrp -R adm /data/mongodb
+  - sudo chmod -R g+rX /data/mongodb
+  - sudo usermod -a -G adm alloy || echo "Could not add alloy to adm group"
   # - sudo mlaunch --replicaset --auth --auth-roles dbAdminAnyDatabase readWriteAnyDatabase userAdminAnyDatabase clusterAdmin clusterMonitor
 
   # Configure Alloy
@@ -121,6 +126,41 @@ write_files:
         }
         {%- endif %}
       }
+    }
+
+    // Tail the mongod logs created by mlaunch under /data/mongodb and ship them to Loki.
+    local.file_match "integrations_mongodb_logs" {
+      path_targets = [{
+        __address__     = "localhost",
+        __path__        = "/data/mongodb/**/mongod.log",
+        instance        = constants.hostname,
+        job             = "integrations/mongodb",
+        mongodb_cluster = "mongodb_sample_app_cluster",
+      }]
+    }
+
+    loki.process "integrations_mongodb_logs" {
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+
+      // MongoDB 8.0 logs are structured JSON; promote severity and component to labels.
+      stage.json {
+        expressions = {
+          level     = "s",
+          component = "c",
+        }
+      }
+
+      stage.labels {
+        values = {
+          level     = null,
+          component = null,
+        }
+      }
+    }
+
+    loki.source.file "integrations_mongodb_logs" {
+      targets    = local.file_match.integrations_mongodb_logs.targets
+      forward_to = [loki.process.integrations_mongodb_logs.receiver]
     }
 
     prometheus.exporter.mongodb "integrations_mongodb_exporter_rs_primary" {

--- a/sample-apps/mongodb/jinja/templates/cloud-init-template_local_setup.yaml
+++ b/sample-apps/mongodb/jinja/templates/cloud-init-template_local_setup.yaml
@@ -30,37 +30,35 @@ runcmd:
   - sudo apt update
   - sudo apt install mongodb-org -y
 
-  # Stop mongod service in case it auto-started
+  # Stop the packaged mongod so it does not hold port 27017
   - sudo systemctl stop mongod
 
-  # Create required directories for each replica set
-  - sudo mkdir -p /srv/mongodb/rs0-0  /srv/mongodb/rs0-1 /srv/mongodb/rs0-2 /srv/mongodb/rs1-0  /srv/mongodb/rs1-1 /srv/mongodb/rs1-2 /srv/mongodb/confrs-0 
+  # Create data and log directories (logs in /var/log/mongodb so the alloy user can read them)
+  - sudo mkdir -p /srv/mongodb/rs0-0 /srv/mongodb/rs0-1 /srv/mongodb/rs0-2 /srv/mongodb/rs1-0 /srv/mongodb/rs1-1 /srv/mongodb/rs1-2 /srv/mongodb/confrs-0 /var/log/mongodb
 
-  # Single member config server replica set
-  - sudo mongod --configsvr --replSet confrs --port 27017 --bind_ip localhost --dbpath /srv/mongodb/confrs-0  --oplogSize 128 &> /root/confrs-0.log &
-
-  # Spawn two shards, each a three-member replicaset
-  - sudo mongod --shardsvr --replSet rs0 --port 27018 --bind_ip localhost --dbpath /srv/mongodb/rs0-0  --oplogSize 128 &> /root/rs0-0.log &
-  - sudo mongod --shardsvr --replSet rs0 --port 27019 --bind_ip localhost --dbpath /srv/mongodb/rs0-1  --oplogSize 128 &> /root/rs0-1.log &
-  - sudo mongod --shardsvr --replSet rs0 --port 27020 --bind_ip localhost --dbpath /srv/mongodb/rs0-2 --oplogSize 128 &> /root/rs0-2.log &
-  - sudo mongod --shardsvr --replSet rs1 --port 27021 --bind_ip localhost --dbpath /srv/mongodb/rs1-0  --oplogSize 128 &> /root/rs1-0.log &
-  - sudo mongod --shardsvr --replSet rs1 --port 27022 --bind_ip localhost --dbpath /srv/mongodb/rs1-1  --oplogSize 128 &> /root/rs1-1.log &
-  - sudo mongod --shardsvr --replSet rs1 --port 27023 --bind_ip localhost --dbpath /srv/mongodb/rs1-2 --oplogSize 128 &> /root/rs1-2.log &
-
-  # mongos instance tbd
-  - sudo mongos --configdb confrs/localhost:27017 --port 27024 --bind_ip localhost &> /root/mongos.log &
-  
-  # Initiate replicasets
-  ## Config server RS
+  # Config server: --fork blocks until it accepts connections (avoids the init race), --logpath captures logs
+  - sudo mongod --configsvr --replSet confrs --port 27017 --bind_ip localhost --dbpath /srv/mongodb/confrs-0 --oplogSize 128 --logpath /var/log/mongodb/confrs-0.log --fork
   - "sudo mongosh localhost:27017 --eval \"rs.initiate({_id: 'confrs', configsvr: true, members: [{_id: 0, host: 'localhost:27017'}]})\""
-  ## rs0
+
+  # Two shards, each a three-member replicaset
+  - sudo mongod --shardsvr --replSet rs0 --port 27018 --bind_ip localhost --dbpath /srv/mongodb/rs0-0 --oplogSize 128 --logpath /var/log/mongodb/rs0-0.log --fork
+  - sudo mongod --shardsvr --replSet rs0 --port 27019 --bind_ip localhost --dbpath /srv/mongodb/rs0-1 --oplogSize 128 --logpath /var/log/mongodb/rs0-1.log --fork
+  - sudo mongod --shardsvr --replSet rs0 --port 27020 --bind_ip localhost --dbpath /srv/mongodb/rs0-2 --oplogSize 128 --logpath /var/log/mongodb/rs0-2.log --fork
+  - sudo mongod --shardsvr --replSet rs1 --port 27021 --bind_ip localhost --dbpath /srv/mongodb/rs1-0 --oplogSize 128 --logpath /var/log/mongodb/rs1-0.log --fork
+  - sudo mongod --shardsvr --replSet rs1 --port 27022 --bind_ip localhost --dbpath /srv/mongodb/rs1-1 --oplogSize 128 --logpath /var/log/mongodb/rs1-1.log --fork
+  - sudo mongod --shardsvr --replSet rs1 --port 27023 --bind_ip localhost --dbpath /srv/mongodb/rs1-2 --oplogSize 128 --logpath /var/log/mongodb/rs1-2.log --fork
   - "sudo mongosh localhost:27018 --eval \"rs.initiate({_id: 'rs0', members: [{_id: 0, host: 'localhost:27018'}, {_id: 1, host: 'localhost:27019'}, {_id: 2, host: 'localhost:27020'}]})\""
-  ## rs1
   - "sudo mongosh localhost:27021 --eval \"rs.initiate({_id: 'rs1', members: [{_id: 0, host: 'localhost:27021'}, {_id: 1, host: 'localhost:27022'}, {_id: 2, host: 'localhost:27023'}]})\""
-  
-  # Add shards via mongos
+
+  # Router: start after the config server replicaset exists, then register the shards
+  - sudo mongos --configdb confrs/localhost:27017 --port 27024 --bind_ip localhost --logpath /var/log/mongodb/mongos.log --fork
   - "sudo mongosh localhost:27024 --eval \"sh.addShard('rs0/localhost:27018,localhost:27019,localhost:27020')\""
   - "sudo mongosh localhost:27024 --eval \"sh.addShard('rs1/localhost:27021,localhost:27022,localhost:27023')\""
+
+  # Let the alloy user read the mongod logs (adm is the conventional log-reader group)
+  - sudo chgrp -R adm /var/log/mongodb
+  - sudo chmod -R g+rX /var/log/mongodb
+  - sudo usermod -a -G adm alloy || echo "Could not add alloy to adm group"
 
   # Configure Alloy
   - sudo systemctl enable alloy.service
@@ -69,11 +67,11 @@ runcmd:
 write_files:
 # Alloy configuration
 
-# Note for mongodb config, there are three separate configs, namely:
-# Configs for mongos (27017) config server (27024) and shard (27018)
-# this is based on `mlaunch --replicaset --sharded 2`
-# which creates two shards for each of the three nodes in the replicaset,
-# plus a mongos and config server on 27017 and 27024 respectively
+# A scrape config is defined per cluster component:
+#   mongos          -> 27024
+#   config server   -> 27017 (replSet confrs)
+#   shard rs0        -> 27018, 27019, 27020
+#   shard rs1        -> 27021, 27022, 27023
 - owner: root:root
   path: /etc/alloy/config.alloy
   content: |
@@ -139,6 +137,41 @@ write_files:
         }
         {%- endif %}
       }
+    }
+
+    // Tail every config-server, shard and mongos log under /var/log/mongodb and ship them to Loki.
+    local.file_match "integrations_mongodb_logs" {
+      path_targets = [{
+        __address__     = "localhost",
+        __path__        = "/var/log/mongodb/*.log",
+        instance        = constants.hostname,
+        job             = "integrations/mongodb",
+        mongodb_cluster = "mongodb_sample_app_cluster",
+      }]
+    }
+
+    loki.process "integrations_mongodb_logs" {
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+
+      // MongoDB 8.0 logs are structured JSON; promote severity and component to labels.
+      stage.json {
+        expressions = {
+          level     = "s",
+          component = "c",
+        }
+      }
+
+      stage.labels {
+        values = {
+          level     = null,
+          component = null,
+        }
+      }
+    }
+
+    loki.source.file "integrations_mongodb_logs" {
+      targets    = local.file_match.integrations_mongodb_logs.targets
+      forward_to = [loki.process.integrations_mongodb_logs.receiver]
     }
 
     prometheus.exporter.mongodb "integrations_mongodb_exporter_mongos" {
@@ -315,7 +348,7 @@ write_files:
     }
 
     prometheus.scrape "integrations_mongodb_exporter_rs1_shard0" {
-      targets    = discovery.relabel.integrations_mongodb_exporter_rs0_shard0.output
+      targets    = discovery.relabel.integrations_mongodb_exporter_rs1_shard0.output
       forward_to = [prometheus.remote_write.metrics_service.receiver]
       job_name   = "integrations/mongodb_exporter"
     }
@@ -375,7 +408,7 @@ write_files:
     }
 
     prometheus.scrape "integrations_mongodb_exporter_rs1_shard2" {
-      targets    = discovery.relabel.integrations_mongodb_exporter_rs0_shard2.output
+      targets    = discovery.relabel.integrations_mongodb_exporter_rs1_shard2.output
       forward_to = [prometheus.remote_write.metrics_service.receiver]
       job_name   = "integrations/mongodb_exporter"
     }


### PR DESCRIPTION
 Updates the sample app to cover the modernized mongodb-mixin:
                                                         
  - Ship mongod logs to Loki (both templates)            
  - Add `make run-cluster` for the sharded cluster    